### PR TITLE
build(deps): bump nginx from 1.27.0-alpine-slim to 1.27.1-alpine-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Must use versions in `major.minor.patch` format as that is expected by a regex
 # (`^FROM\s+\S+:\K[0-9]+\.[0-9]+\.[0-9]+`) used in other scripts
-FROM nginx:1.27.0-alpine-slim
+FROM nginx:1.27.1-alpine-slim
 
 # In order to run the Docker image in non-root mode, the Nginx binaries need to
 # be opened up to non-root users


### PR DESCRIPTION
The repo was started at 1.27.0. This PR helps to publish 1.27.1. Will leave 1.27.2 (the latest version) to dependabot later.

Versions before 1.27 can be added when needed. For now, it's fine to only have the newer versions.